### PR TITLE
Trim API key when building request headers.

### DIFF
--- a/TextRazor.php
+++ b/TextRazor.php
@@ -185,7 +185,7 @@ class TextRazorConnection {
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $textrazorParams);
 
         $headers = array();
-        $headers[] = 'X-TextRazor-Key: ' . $this->apiKey;
+        $headers[] = 'X-TextRazor-Key: ' . trim($this->apiKey);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 


### PR DESCRIPTION
Extra whitespace (particularly trailing \n characters) can cause problems; trim for safety.